### PR TITLE
Removed explicit JSON serialization and unnecessary client ID and secret

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ module.exports = class DynamoDBContextStore {
                 } else {
                     if (data.Item) {
                         let result = data.Item;
-                        result.config = JSON.parse(result.config);
+
+                        // For backward compatibility with version 1.0.1
+                        if (typeof result.config === 'string') {
+                            result.config = JSON.parse(result.config);
+                        }
                         resolve(result);
                     }
                     else {
@@ -43,9 +47,7 @@ module.exports = class DynamoDBContextStore {
                 locationId: params.locationId,
                 authToken: params.authToken,
                 refreshToken: params.refreshToken,
-                clientId: params.clientId,
-                clientSecret: params.clientSecret,
-                config: JSON.stringify(params.config)
+                config: params.config
             }
         };
         return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartthings/dynamodb-context-store",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Stores SmartApp configuration and auth tokens for use in app-initiated calls",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Stopped explicitly serializing the `config` field in Javascript since DynamoDB accepts the object. Still deserializes on read if the DB value is a string so it is backward compatible.

Also removed clientId and clientSecret, since they were not used and storing them in multiple places is not the best security practice.