### PR TITLE
feat: Pick up AWS_REGION from environment variable

### DIFF
--- a/lib/dynamodb-context-store.js
+++ b/lib/dynamodb-context-store.js
@@ -77,7 +77,7 @@ module.exports = class DynamoDBContextStore {
 			} else if (options.AWSConfigJSON) {
 				AWS.config.update(options.AWSConfigJSON)
 			} else {
-				this.AWSRegion = options.AWSRegion || 'us-east-1'
+				this.AWSRegion = options.AWSRegion || (process.env.AWS_REGION || 'us-east-1')
 				AWS.config.update({region: this.AWSRegion})
 			}
 


### PR DESCRIPTION
Change to pick up AWS_REGION from environment variable just as the AWS SDK does for access credentials.