### PR TITLE
feat: change to AWS SDK V3 and release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The context stored by this module consists of the following data elements:
 * **authToken**: the access token used in calling the API
 * **refreshToken**: the refresh token used in generating a new access token when one expires
 * **config**: the current installed app instance configuration, i.e. selected devices, options, etc.
-* **state**: name-value storage for the installed app instance
 
 **_Note: Version 3.X.X is a breaking change to version 2.X.X as far as configuring the context store is
 concerned, but either one can be used with any version of the SmartThings SDK. The new state storage


### PR DESCRIPTION
BREAKING CHANGE: The initialization of the context store is not backward compatible since the AWS V3 client is initialized differently than the V2 client. Otherwise, the operation of the context store is backward compatible with the 2.X version